### PR TITLE
fix: CI Node version (from .nvmrc) + KaTeX dark-mode color

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
 
-    strategy:
-      matrix:
-        node-version: [20]
-
     steps:
       - name: "☁️ Checkout repository"
         uses: actions/checkout@v4
@@ -31,10 +27,10 @@ jobs:
         with:
           version: 10.11.1
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: "⬢ Use Node.js (from .nvmrc)"
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: "📦 Install dependencies"

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -94,6 +94,13 @@
       @apply focus-visible:outline-accent focus-visible:border-transparent focus-visible:outline-2 focus-visible:outline-dashed;
     }
 
+    /* KaTeX math inherits the prose base color by default, which doesn't track
+       the dark theme (no prose-invert here). Force the theme foreground so
+       display math stays legible in dark mode. */
+    .katex {
+      @apply text-foreground;
+    }
+
     /* Allow wide KaTeX display equations to scroll horizontally on narrow screens */
     .katex-display {
       @apply overflow-x-auto overflow-y-hidden;


### PR DESCRIPTION
两个相互独立的小修复，放在一起提交。

## 1. CI 的 Node 版本（修构建报错）

CI 跑在 Node 20，但 Astro 6 要求 `>=22.12.0`，构建步骤直接报错：`Node.js v20.20.2 is not supported by Astro!`。项目升到 Astro 6 时，CI 的 Node 版本漏改了（`.nvmrc` 和 Cloudflare Pages 都已是 24）。

改为通过 setup-node 的 `node-version-file: ".nvmrc"` 读取版本，让 CI / Cloudflare Pages / 本地开发共用 `.nvmrc` 这一个来源，避免再次漂移；同时去掉只有单个版本的 build matrix。

## 2. KaTeX 公式在暗色模式下颜色不对（修可读性）

块级公式 `.katex-display` 是 `.app-prose` 的块级子元素，不在 typography.css 的 `text-foreground` 覆写列表里，于是继承了 Tailwind Typography 的默认 prose 正文色。该默认色在本项目里不随主题变化（没用 `prose-invert`，暗色靠 `[data-theme=dark]`），导致块级公式在暗色背景下呈暗灰、几乎看不见；行内公式因为继承了 `<p>` 的颜色才正常。

将 `.katex` 强制为 `text-foreground`，行内与块级公式都跟随主题前景色（暗 `#eaedf3` / 亮 `#282728`），分数线、积分号、svg 字形通过 `currentColor` 一并跟随。

## 验证

- `pnpm exec astro build` 通过；编译后 CSS 含 `.app-prose .katex{color:var(--foreground)}`。
- 本地 `pnpm run lint` 与 `pnpm run format:check` 通过。
- 暗色 token 确认：`[data-theme=dark]` 下 `--foreground:#eaedf3`（近白），公式即随之变亮。
- 注：本次未能截图（Chrome 扩展未连接），暗色效果通过编译后 CSS + 主题 token 的级联确认，非像素级截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)